### PR TITLE
Corrección bug Berengario día 3

### DIFF
--- a/vigasoco/AbadiaDriver.cpp
+++ b/vigasoco/AbadiaDriver.cpp
@@ -148,6 +148,31 @@ void AbadiaDriver::filesLoaded()
 	memcpy(&romsPtr[0x24000-1+_gameFiles[1]->getTotalSize()+21600],_gameFiles[1]->getData(),_gameFiles[1]->getTotalSize());
 	memcpy(&romsPtr[0x24000-1+(_gameFiles[1]->getTotalSize()+21600)*2],_gameFiles[2]->getData(),_gameFiles[1]->getTotalSize());
 	// Los sonidos no se copian, y se cargan directamente en Audioplugin
+
+        // En la versión 0.09 se incluyeron nuevos caracteres para soportar nuevos idiomas
+        // Esos nuevos caracteres incluian '-' y '.' , a los que se le añadio nuevo gráfico
+        // Pero en el código original algunos caracteres como - . > /
+        // se usan para representar varios caracteres a la vez
+        // Por ejemplo, COMPLETAS no cabe en el hueco del Marcador
+        // donde se muestra el día
+        // Y en la ROM está grabado como COM-./>
+        // El gráfico del guión es el texto PL comprimido y ajustado para que
+        // COMPLETAS entre en el marcador
+        //
+        // Parcheamos el texto de COMPLETAS en la ROM para que en vez de usar - y .
+        // como caracteres especiales que representan varias letras a la vez,
+        // se usen @ y ~  , que son códigos ASCII que no se usan en ninguno de los
+        // nuevos textos multiidioma
+        // Junto a este cambio, se modifica Marcador::imprimirCaracter para que
+        // se tenga en cuenta este parche y cuando se imprima @ o ~
+        // se usan los antiguos gráficos asociados a - y .
+        //
+        // Accedemos a la posición de la ROM dónd está el texto COM-./>
+        UINT8*tmp=&romsPtr[0x4000+0x4fbc + 7*6];
+        // Modificamos el tercer byte cambiando - por #
+        *(tmp+3)='#';
+        // Modificamos el cuarto byte cambiando . por ~
+        *(tmp+4)='~';
 }
 
 // reordena los datos gr?ficos y los copia en el destino

--- a/vigasoco/AccionesDia.cpp
+++ b/vigasoco/AccionesDia.cpp
@@ -136,6 +136,15 @@ void AccionesPrima::ejecuta(AccionesDia *ad)
 	}
 
 	if (laLogica->dia == 3){
+		// en el código en ensamblador original Jorge y Berengario son el mismo
+		// ya que nunca coinciden (también Bernardo) y comparten estructura en memoria
+		// pero en Vigasoco Jorge y Berengario son dos objetos distintos
+		// así que si el día II se duerme y Berengario no llega a robar el libro
+		// y morir en la celda de Severino se queda andando zombie por la abadía
+		// Así que aquí tenemos que asegurarnos que Berengario no pasa al día 3
+		laLogica->berengario->estaVivo=false;
+		laLogica->berengario->posX= laLogica->berengario->posY= laLogica->berengario->altura=0;
+
 		// jorge coge el libro y lo esconde
 		laLogica->jorge->objetos = LIBRO;
 		ad->colocaObjeto(elJuego->objetos[0], 0x0f, 0x2e, 0x00);


### PR DESCRIPTION
En el código en ensamblador original Jorge y Berengario comparten estructura en memoria ya que nunca coinciden. Simplemente se cambia el gráfico de la cara.
Así que si el día II se duerme y no se completan las acciones de la noche en las que Berengario roba el libro y va a morir a la celda de Severino, pues no pasa nada, porque al iniciar el día III Berengario pasa a ser Jorge.
Pero en Vigasoco Jorge y Berengario son dos objetos distintos
 así que si el día II se duerme y Berengario no llega a robar el libro
 y morir en la celda de Severino se queda andando zombie por la abadía

El parche añade a las acciones de la hora prima del día 3 el que Berengario muera y no quede activo